### PR TITLE
Add telegram user filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Welcome to the ComfyUI Serving Toolkit, a powerful tool for serving image generation workflows in Discord and other platforms (soon).
 This toolkit is designed to simplify the process of serving your ComfyUI workflow, making image generation bots easier than ever before.
 You can serve on discord, or on websockets.
+* allowed_user - (Optional) The Telegram username of the user allowed to use the bot. If not set, all users can use the bot.
 
 If you need any help, Checkout the [Discord!](https://discord.gg/AyHFchFZuV)
 

--- a/nodes/telegram_serving.py
+++ b/nodes/telegram_serving.py
@@ -20,6 +20,8 @@ class TelegramServing:
     def telegram_handler(self):
         @self.bot.message_handler(commands=[self.command_name])
         def handle_command(message):
+            if self.allowed_user and message.from_user.username != self.allowed_user:
+                return  # Silently ignore messages from unauthorized users
             print(f"Received command from {message.chat.id}: {message.text}")
             parsed_data = parse_command_string(message.text, self.command_name)
             
@@ -72,7 +74,13 @@ class TelegramServing:
                     "multiline": False,
                     "default": "generate"
                 })
+            "optional": {
+                "allowed_user": ("STRING", {
+                    "multiline": False,
+                    "default": ""
+                })
             }
+        }
         }
 
     RETURN_TYPES = ("SERVING_CONFIG",)
@@ -83,10 +91,11 @@ class TelegramServing:
     def IS_CHANGED(cls, **kwargs):
         return float("NaN")
 
-    def serve(self, telegram_token, command_name):
+    def serve(self, telegram_token, command_name, allowed_user=""):
         if not self.telegram_running:
             self.bot = telebot.TeleBot(telegram_token)
             self.command_name = command_name
+            self.allowed_user = allowed_user
             threading.Thread(target=self.telegram_handler, daemon=True).start()
             print(f"Telegram bot running, listening for /{command_name} commands")
             self.telegram_running = True


### PR DESCRIPTION
Solution for: 
```
Add the telegram serving node an option to only allow a certain user to use the node.
if no user has been given, the behavior should stay the same
if a user has been given, it should ignore their message and do nothing (not even throw error)
```